### PR TITLE
fix(plugins): readd `new` to the plugins config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2025-10-17
+
+- Readd the `now` alias to `40_plugins.lua`.
+  It was removed in the change below (Move `now_if_args`...).
+  It was readded, because it allows new users to uncomment the example for color schemes outside of mini.hue without further adjustments.
+
 ## 2025-10-16
 
 - Move `now_if_args` startup helper to 'init.lua' as `_G.Config.now_if_args` to be directly usable from other config files.

--- a/configs/nvim-0.11/plugin/40_plugins.lua
+++ b/configs/nvim-0.11/plugin/40_plugins.lua
@@ -9,7 +9,7 @@
 -- Use this file to install and configure other such plugins.
 
 -- Make concise helpers for installing/adding plugins in two stages
-local add, later = MiniDeps.add, MiniDeps.later
+local add, now, later = MiniDeps.add, MiniDeps.now, MiniDeps.later
 local now_if_args = _G.Config.now_if_args
 
 -- Tree-sitter ================================================================


### PR DESCRIPTION
- [x] This PR does not suggest changes based on personal taste (enabling new or changing value of existing option, install new plugin)

I was confused why `now` was removed when adapting the fix for mini.misc.
My guess is that the reasoning was that it should be fine for most plugins outside of mini to run `later` or that it was done on accident.
From my point of view it is better to include it because it is used in the color scheme example and because one might need `now` for other plugins too.

Still involves a bit of personal taste I guess.

Thanks for this fantastic project and mini.nvim in general. Using it is a joy.
