### PR TITLE
chore: missing clue for mini.surround

### DIFF
--- a/configs/nvim-0.11/plugin/30_mini.lua
+++ b/configs/nvim-0.11/plugin/30_mini.lua
@@ -291,6 +291,7 @@ later(function()
       { mode = 'n', keys = '<Leader>' }, -- Leader triggers
       { mode = 'x', keys = '<Leader>' },
       { mode = 'n', keys = '\\' },       -- mini.basics
+      { mode = 'n', keys = 's' },        -- mini.surround
       { mode = 'n', keys = '[' },        -- mini.bracketed
       { mode = 'n', keys = ']' },
       { mode = 'x', keys = '[' },


### PR DESCRIPTION
Adding missing clue for surround, nothing big

- [ ] This PR does not suggest changes based on personal taste (enabling new or changing value of existing option, install new plugin)
