### PR TITLE
docs(requirements): mention tree-sitter-cli in requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ It is not a comprehensive guide on how to set up and use every Neovim feature an
 - [Git](https://git-scm.com/) executable. Assumed to be named `git`.
 - Operating system: any OS supported by Neovim.
 - Internet connection for downloading plugins.
+- [Treesitter CLI](https://github.com/tree-sitter/tree-sitter/blob/master/crates/cli/README.md) for installing tree-sitter grammars
 - (Optional, but recommended) [`ripgrep`](https://github.com/BurntSushi/ripgrep#installation).
 - (Optional, but recommended) Terminal emulator (or GUI) with [true colors](https://github.com/termstandard/colors#truecolor-support-in-output-devices) and [Nerd Font icons](https://www.nerdfonts.com/) support. No need for a full Nerd font, using [`NerdFontsSymbolsOnly`](https://github.com/ryanoasis/nerd-fonts/releases/latest) as a fallback is usually enough.
 


### PR DESCRIPTION
- [x] This PR does not suggest changes based on personal taste (enabling new or changing value of existing option, install new plugin)

I spent an hour trying to understand why my tree-sitter would not install new grammars. I have not used tree-sitter `main` branch before and haven't bothered to check their documentation, where they explicitly mention cli as a requirement.

I expect that I will not be alone in this, as many people still rely on `master` branch. It might be an even bigger issue for newcomers or people who used to rely on Neovim distros.

I am not 100% sure in my writing skills, so feel free to change it!

